### PR TITLE
Improve readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # FreeCam
 
-Controls :
-Keypad . : toggle on/off
-Keypad / : 0% game speed
-Keypad * : 50% game speed
-Keypad - : 100% game speed
-Keypad + : slow speed
-Keypad Enter : fast speed
-(Hold left shift to double current speed)
-Keypad 0 : Lock onto player
-Keypad 1 : Lock onto the sun
-Keypad 2 : Lock onto the interloper
-Keypad 3 : Lock onto ember twin
-Keypad 4 : Lock onto ash twin
-Keypad 5 : Lock onto timber hearth
-Keypad 6 : Lock onto brittle hollow
-Keypad 7 : Lock onto giants deep
-Keypad 8 : Lock onto dark bramble
-Keypad 9 : teleport to player
+## Controls
+
+| **Key**  | **Function**  |
+|---|---|
+| Keypad . | Toggle on/off  |
+| Keypad / | 0% game speed  |
+| Keypad * | 50% game speed  |
+| Keypad - | 100% game speed  |
+| Keypad + | Slow speed |
+| Keypad Enter | Fast speed (Hold left shift to double current speed) |
+| Keypad 0 | Lock onto player |
+| Keypad 1 | Lock onto the sun |
+| Keypad 2 | Lock onto the Interloper |
+| Keypad 3 | Lock onto Ember Twin |
+| Keypad 4 | Lock onto Ash Twin |
+| Keypad 5 | Lock onto Timber Hearth |
+| Keypad 6 | Lock onto Brittle Hollow |
+| Keypad 7 | Lock onto Giant's Deep |
+| Keypad 8 | Lock onto Dark Bramble |
+| Keypad 9 | Teleport to player |


### PR DESCRIPTION
The readme was missing double spacing which made it all jam into one line. Figured may as well fix it nice, so now it's formatted in a happy little table.