### PR TITLE
Increase default move speed & allow rotation speed to be adjusted

### DIFF
--- a/FreeCam/Components/CustomLookAround.cs
+++ b/FreeCam/Components/CustomLookAround.cs
@@ -11,7 +11,7 @@ public class CustomLookAround : MonoBehaviour
     private float _moveX;
     private float _moveY;
 
-    private float _moveSpeed = 0.1f;
+    private float _moveSpeed = 1f;
 
     void Start() => Cursor.lockState = CursorLockMode.Locked;
 
@@ -45,12 +45,12 @@ public class CustomLookAround : MonoBehaviour
 
         if (Keyboard.current[Key.Q].isPressed)
         {
-            transform.Rotate(Vector3.forward, 0.25f);
+            transform.Rotate(Vector3.forward, (float)Math.Log(_moveSpeed * 0.1f + 1));
         }
 
         if (Keyboard.current[Key.E].isPressed)
         {
-            transform.Rotate(Vector3.forward, -0.25f);
+            transform.Rotate(Vector3.forward, -(float)Math.Log(_moveSpeed * 0.1f + 1));
         }
     }
 }


### PR DESCRIPTION
Both the default movement speed and the (unadjustable) rotational speed are way too slow. Not sure if this is intended.

I added a logarithmic formula for the rotational speed based on movement speed. Not fully sure if this formula is the best but it seems to work decently intuitively to me.