### PR TITLE
Improved controls

### DIFF
--- a/FreeCam/Components/CustomLookAround.cs
+++ b/FreeCam/Components/CustomLookAround.cs
@@ -23,7 +23,7 @@ public class CustomLookAround : MonoBehaviour
             return;
         }
 
-        var scrollInOut = Mouse.current.scroll.y.ReadValue();
+        var scrollInOut = Mouse.current.scroll.y.ReadValue() + InputLibrary.toolOptionUp.GetValue() - InputLibrary.toolOptionDown.GetValue();
         _moveSpeed = Math.Max(_moveSpeed + scrollInOut * 0.05f, 0f);
 
         if (Keyboard.current[Key.DownArrow].wasPressedThisFrame)
@@ -41,8 +41,14 @@ public class CustomLookAround : MonoBehaviour
 
         _moveY = OWInput.GetValue(InputLibrary.thrustUp) - OWInput.GetValue(InputLibrary.thrustDown);
 
-        transform.Rotate(Vector3.up, _degreesX);
+        if (OWInput.IsPressed(InputLibrary.rollMode)) {
+            transform.Rotate(Vector3.forward, -_degreesX);
+        }
+        else {
+            transform.Rotate(Vector3.up, _degreesX);
+        }
         transform.Rotate(Vector3.right, -_degreesY);
+
         transform.position += _moveZ * (transform.forward * 0.02f * _moveSpeed);
         transform.position += _moveX * (transform.right * 0.02f * _moveSpeed);
         transform.position += _moveY * (transform.up * 0.02f * _moveSpeed);

--- a/FreeCam/Components/CustomLookAround.cs
+++ b/FreeCam/Components/CustomLookAround.cs
@@ -38,7 +38,8 @@ public class CustomLookAround : MonoBehaviour
 
         var lookRate = OWInput.UsingGamepad() ? PlayerCameraController.GAMEPAD_LOOK_RATE_Y : PlayerCameraController.LOOK_RATE;
         
-        var look = InputLibrary.look.GetAxisValue(true);
+        // Possibly this should use the ship input version? Since the freecam controls are more like flight
+        var look = OWInput.GetAxisValue(InputLibrary.look, InputMode.All);
         _degreesY = look.y * lookRate * Time.unscaledDeltaTime;
         _degreesX = look.x * lookRate * Time.unscaledDeltaTime;
 

--- a/FreeCam/Components/FreeCamController.cs
+++ b/FreeCam/Components/FreeCamController.cs
@@ -28,8 +28,11 @@ public class FreeCamController : MonoBehaviour
     };
 
     public const Key TeleportKey = Key.T;
+    public const Key ReparentKey = Key.Y;
 
     public static bool HoldingTeleport { get; private set; }
+
+    public void Start() => ParentToPlayer(true);
 
     public void Update()
     {
@@ -49,14 +52,13 @@ public class FreeCamController : MonoBehaviour
         }
 
         HoldingTeleport = false;
-        if (Keyboard.current[TeleportKey].isPressed)
+        if (Keyboard.current[TeleportKey].isPressed || Keyboard.current[ReparentKey].isPressed)
         {
             HoldingTeleport = true;
 
             if (Keyboard.current[CenterOnPlayerKey].wasPressedThisFrame || Keyboard.current[CenterOnPlayerKeyAlt].wasPressedThisFrame)
             {
-                transform.parent = Locator.GetPlayerTransform();
-                transform.position = Locator.GetPlayerTransform().position;
+                ParentToPlayer(Keyboard.current[TeleportKey].isPressed);
             }
 
             foreach (var planet in CenterOnPlanetKey.Keys)
@@ -64,9 +66,7 @@ public class FreeCamController : MonoBehaviour
                 var (key, alt) = CenterOnPlanetKey[planet];
                 if (Keyboard.current[key].wasPressedThisFrame || Keyboard.current[alt].wasPressedThisFrame)
                 {
-                    var go = Locator.GetAstroObject(planet).gameObject.transform;
-                    transform.parent = go;
-                    transform.position = go.position;
+                    ParentToAstroObject(Locator.GetAstroObject(planet), Keyboard.current[TeleportKey].isPressed);
                 }
             }
         }
@@ -79,6 +79,25 @@ public class FreeCamController : MonoBehaviour
         if (Keyboard.current[ToggleKey].wasPressedThisFrame || Keyboard.current[ToggleKeyAlt].wasPressedThisFrame)
         {
             MainClass.ToggleFreeCam();
+        }
+    }
+
+    public void ParentToPlayer(bool warp = false)
+    {
+        var playerCameraTransform = Locator.GetPlayerCamera().transform;
+        transform.parent = playerCameraTransform;
+        if (warp) {
+            transform.position = playerCameraTransform.position;
+            transform.rotation = playerCameraTransform.rotation;
+        }
+    }
+
+    public void ParentToAstroObject(AstroObject astroObject, bool warp = false)
+    {
+        var astroObjectTransform = astroObject.gameObject.transform;
+        transform.parent = astroObjectTransform;
+        if (warp) {
+            transform.position = astroObjectTransform.position;
         }
     }
 }

--- a/FreeCam/Components/PromptController.cs
+++ b/FreeCam/Components/PromptController.cs
@@ -7,7 +7,7 @@ namespace FreeCam.Components;
 
 public class PromptController : MonoBehaviour
 {
-    private ScreenPrompt _togglePrompt, _guiPrompt, _teleportOptions, _scrollPrompt, _rotatePrompt, _horizontalPrompt, _verticalPrompt;
+    private ScreenPrompt _togglePrompt, _guiPrompt, _teleportOptions, _scrollPrompt, _scrollSpeedPrompt, _rotatePrompt, _horizontalPrompt, _verticalPrompt;
     private ScreenPrompt _centerPrompt;
     private List<ScreenPrompt> _planetPrompts;
 
@@ -16,6 +16,7 @@ public class PromptController : MonoBehaviour
     private ScreenPrompt _flashlightPrompt, _flashlightRangePrompt, _flashlightSpeedPrompt;
 
     private CustomFlashlight _customFlashlight;
+    private CustomLookAround _customLookAround;
 
     private static readonly UIInputCommands _rotateLeftCmd = new("FREECAM - RotateLeft", KeyCode.Q);
     private static readonly UIInputCommands _rotateRightCmd = new("FREECAM - RotateRight", KeyCode.E);
@@ -27,6 +28,7 @@ public class PromptController : MonoBehaviour
     private void Start()
     {
         _customFlashlight = GetComponent<CustomFlashlight>();
+        _customLookAround = GetComponent<CustomLookAround>();
 
         // Top right
         _togglePrompt = AddPrompt("Toggle FreeCam", PromptPosition.UpperLeft, FreeCamController.ToggleKey);
@@ -34,6 +36,9 @@ public class PromptController : MonoBehaviour
 
         _scrollPrompt = new ScreenPrompt(_scrollCmd, _resetCmd, "Movement speed   <CMD1> Reset   <CMD2>", ScreenPrompt.MultiCommandType.CUSTOM_BOTH);
         Locator.GetPromptManager().AddScreenPrompt(_scrollPrompt, PromptPosition.UpperLeft, false);
+
+        _scrollSpeedPrompt = new ScreenPrompt("Move Speed: " + _customLookAround.MoveSpeed + " m/s");
+        Locator.GetPromptManager().AddScreenPrompt(_scrollSpeedPrompt, PromptPosition.UpperLeft, false);
 
         _horizontalPrompt = new ScreenPrompt(InputLibrary.moveXZ, "Move   <CMD>");
         Locator.GetPromptManager().AddScreenPrompt(_horizontalPrompt, PromptPosition.UpperLeft, false);
@@ -80,6 +85,8 @@ public class PromptController : MonoBehaviour
 
         _guiPrompt.SetVisibility(visible && MainClass.InFreeCam);
         _scrollPrompt.SetVisibility(visible && MainClass.InFreeCam);
+        _scrollSpeedPrompt.SetVisibility(visible && MainClass.InFreeCam);
+        _scrollSpeedPrompt.SetText("Move Speed: " + _customLookAround.MoveSpeed + " m/s");
         _horizontalPrompt.SetVisibility(visible && MainClass.InFreeCam);
         _verticalPrompt.SetVisibility(visible && MainClass.InFreeCam);
         _rotatePrompt.SetVisibility(visible && MainClass.InFreeCam);

--- a/FreeCam/Components/PromptController.cs
+++ b/FreeCam/Components/PromptController.cs
@@ -70,7 +70,7 @@ public class PromptController : MonoBehaviour
 
     private void Update()
     {
-        var visible = !OWTime.IsPaused() && !GUIMode.IsHiddenMode() && MainClass.ShowPrompts;
+        var visible = !OWTime.IsPaused() && !GUIMode.IsHiddenMode() && PlayerData.GetPromptsEnabled() && MainClass.ShowPrompts;
 
         // Top right
         _togglePrompt.SetVisibility(visible);

--- a/FreeCam/Components/PromptController.cs
+++ b/FreeCam/Components/PromptController.cs
@@ -7,13 +7,12 @@ namespace FreeCam.Components;
 
 public class PromptController : MonoBehaviour
 {
-    private ScreenPrompt _togglePrompt, _guiPrompt, _teleportOptions, _scrollPrompt, _scrollSpeedPrompt, _rotatePrompt, _horizontalPrompt, _verticalPrompt;
-    private ScreenPrompt _centerPrompt;
-    private List<ScreenPrompt> _planetPrompts;
-
-    private List<ScreenPrompt> _timePrompts;
-
-    private ScreenPrompt _flashlightPrompt, _flashlightRangePrompt, _flashlightSpeedPrompt;
+    private ScreenPrompt
+        _togglePrompt, _guiPrompt, _teleportOptions, _centerPlayerPrompt,
+        _scrollPromptKeyboard, _scrollPromptGamepad, _speedPrompt,
+        _rotatePrompt, _horizontalPrompt, _verticalPrompt, _lookPrompt,
+        _flashlightPrompt, _flashlightRangePrompt, _flashlightSpeedPrompt;
+    private List<ScreenPrompt> _planetPrompts, _timePrompts;
 
     private CustomFlashlight _customFlashlight;
     private CustomLookAround _customLookAround;
@@ -29,51 +28,44 @@ public class PromptController : MonoBehaviour
     {
         _customFlashlight = GetComponent<CustomFlashlight>();
         _customLookAround = GetComponent<CustomLookAround>();
-
+        
         // Top right
         _togglePrompt = AddPrompt("Toggle FreeCam", PromptPosition.UpperLeft, FreeCamController.ToggleKey);
         _guiPrompt = AddPrompt("Hide HUD", PromptPosition.UpperLeft, FreeCamController.GUIKey);
 
-        _scrollPrompt = new ScreenPrompt(_scrollCmd, _resetCmd, "Movement speed   <CMD1> Reset   <CMD2>", ScreenPrompt.MultiCommandType.CUSTOM_BOTH);
-        Locator.GetPromptManager().AddScreenPrompt(_scrollPrompt, PromptPosition.UpperLeft, false);
+        _scrollPromptKeyboard = AddPrompt("Change speed   <CMD1> Reset   <CMD2>", PromptPosition.UpperLeft, [_scrollCmd, _resetCmd], ScreenPrompt.MultiCommandType.CUSTOM_BOTH);
+        _scrollPromptGamepad = AddPrompt("Change speed   <CMD>", PromptPosition.UpperLeft, [InputLibrary.toolOptionUp, InputLibrary.toolOptionDown], ScreenPrompt.MultiCommandType.POS_NEG);
+        _speedPrompt = AddPrompt("Speed: " + _customLookAround.MoveSpeed + " m/s", PromptPosition.UpperLeft);
 
-        _scrollSpeedPrompt = new ScreenPrompt("Move Speed: " + _customLookAround.MoveSpeed + " m/s");
-        Locator.GetPromptManager().AddScreenPrompt(_scrollSpeedPrompt, PromptPosition.UpperLeft, false);
+        _rotatePrompt = AddPrompt(
+            UITextLibrary.GetString(UITextType.RollPrompt) + " <CMD1>" + UITextLibrary.GetString(UITextType.HoldPrompt) + "  +<CMD2>", PromptPosition.UpperLeft,
+            [InputLibrary.rollMode, InputLibrary.look], ScreenPrompt.MultiCommandType.CUSTOM_BOTH
+        );
 
-        _horizontalPrompt = new ScreenPrompt(InputLibrary.moveXZ, "Move   <CMD>");
-        Locator.GetPromptManager().AddScreenPrompt(_horizontalPrompt, PromptPosition.UpperLeft, false);
-
-        _verticalPrompt = new ScreenPrompt(InputLibrary.thrustUp, InputLibrary.thrustDown, "Up/Down   <CMD>", ScreenPrompt.MultiCommandType.POS_NEG);
-        Locator.GetPromptManager().AddScreenPrompt(_verticalPrompt, PromptPosition.UpperLeft, false);
-
-        _rotatePrompt = new ScreenPrompt(_rotateLeftCmd, _rotateRightCmd, "Rotate   <CMD1> <CMD2>", ScreenPrompt.MultiCommandType.CUSTOM_BOTH);
-        Locator.GetPromptManager().AddScreenPrompt(_rotatePrompt, PromptPosition.UpperLeft, false);
+        _lookPrompt = AddPrompt(UITextLibrary.GetString(UITextType.LookPrompt) + "   <CMD>", PromptPosition.UpperLeft, InputLibrary.look);
+        _horizontalPrompt = AddPrompt(UITextLibrary.GetString(UITextType.MovePrompt) + "   <CMD>", PromptPosition.UpperLeft, InputLibrary.moveXZ);
+        _verticalPrompt = AddPrompt("Up/Down   <CMD>", PromptPosition.UpperLeft, [InputLibrary.thrustUp, InputLibrary.thrustDown], ScreenPrompt.MultiCommandType.POS_NEG);
 
         // Top Left
         _teleportOptions = AddPrompt("Parent options   <CMD>" + UITextLibrary.GetString(UITextType.HoldPrompt), PromptPosition.UpperRight, FreeCamController.TeleportKey);
-        _centerPrompt = AddPrompt("Player", PromptPosition.UpperRight, FreeCamController.CenterOnPlayerKey);
+        _centerPlayerPrompt = AddPrompt("Player", PromptPosition.UpperRight, FreeCamController.CenterOnPlayerKey);
 
-        _planetPrompts = new();
+        _planetPrompts = [];
         foreach (var planet in FreeCamController.CenterOnPlanetKey.Keys)
         {
             _planetPrompts.Add(AddPrompt(AstroObject.AstroObjectNameToString(planet), PromptPosition.UpperRight, FreeCamController.CenterOnPlanetKey[planet].key));
         }
 
         // Flashlight
-        _flashlightPrompt = new ScreenPrompt(InputLibrary.flashlight, UITextLibrary.GetString(UITextType.FlashlightPrompt) + "   <CMD>" + UITextLibrary.GetString(UITextType.PressPrompt));
-        Locator.GetPromptManager().AddScreenPrompt(_flashlightPrompt, PromptPosition.UpperLeft, false);
-
-        _flashlightRangePrompt = new ScreenPrompt(_rangeDown, _rangeUp, "Flashlight range   <CMD1> <CMD2>", ScreenPrompt.MultiCommandType.CUSTOM_BOTH);
-        Locator.GetPromptManager().AddScreenPrompt(_flashlightRangePrompt, PromptPosition.UpperLeft, false);
-
+        _flashlightPrompt = AddPrompt(UITextLibrary.GetString(UITextType.FlashlightPrompt) + "   <CMD>" + UITextLibrary.GetString(UITextType.PressPrompt), PromptPosition.UpperLeft, InputLibrary.flashlight);
+        _flashlightRangePrompt = AddPrompt("Flashlight range   <CMD1> <CMD2>", PromptPosition.UpperLeft, [_rangeDown, _rangeUp], ScreenPrompt.MultiCommandType.CUSTOM_BOTH);
         _flashlightSpeedPrompt = AddPrompt("Adjust range faster   <CMD>" + UITextLibrary.GetString(UITextType.HoldPrompt), PromptPosition.UpperLeft, Key.RightShift);
 
-        _timePrompts = new()
-        {
+        _timePrompts = [
             AddPrompt("0% game speed", PromptPosition.LowerLeft, Key.Comma),
             AddPrompt("50% game speed", PromptPosition.LowerLeft, Key.Period),
             AddPrompt("100% game speed", PromptPosition.LowerLeft, Key.Slash)
-        };
+        ];
     }
 
     private void Update()
@@ -82,18 +74,27 @@ public class PromptController : MonoBehaviour
 
         // Top right
         _togglePrompt.SetVisibility(visible);
-
         _guiPrompt.SetVisibility(visible && MainClass.InFreeCam);
-        _scrollPrompt.SetVisibility(visible && MainClass.InFreeCam);
-        _scrollSpeedPrompt.SetVisibility(visible && MainClass.InFreeCam);
-        _scrollSpeedPrompt.SetText("Move Speed: " + _customLookAround.MoveSpeed + " m/s");
+
+        var usingGamepad = Locator.GetPromptManager()._usingGamepad;
+        _scrollPromptGamepad.SetVisibility(visible && MainClass.InFreeCam && usingGamepad);
+        _scrollPromptKeyboard.SetVisibility(visible && MainClass.InFreeCam && !usingGamepad);
+
+        _speedPrompt.SetVisibility(visible && MainClass.InFreeCam);
+        var moveSpeed = _customLookAround.MoveSpeed;
+        string moveSpeedString;
+        if (moveSpeed < 0.01f || moveSpeed > 100f) { moveSpeedString = moveSpeed.ToString("0.000e0"); }
+        else { moveSpeedString = moveSpeed.ToString("0.000"); }
+        _speedPrompt.SetText("Speed: " + moveSpeedString + " m/s");
+
+        _rotatePrompt.SetVisibility(visible && MainClass.InFreeCam);
+        _lookPrompt.SetVisibility(visible && MainClass.InFreeCam);
         _horizontalPrompt.SetVisibility(visible && MainClass.InFreeCam);
         _verticalPrompt.SetVisibility(visible && MainClass.InFreeCam);
-        _rotatePrompt.SetVisibility(visible && MainClass.InFreeCam);
 
         // Top left
         _teleportOptions.SetVisibility(visible && MainClass.InFreeCam);
-        _centerPrompt.SetVisibility(visible && MainClass.InFreeCam && FreeCamController.HoldingTeleport);
+        _centerPlayerPrompt.SetVisibility(visible && MainClass.InFreeCam && FreeCamController.HoldingTeleport);
         foreach (var planetPrompt in _planetPrompts)
         {
             planetPrompt.SetVisibility(visible && MainClass.InFreeCam && FreeCamController.HoldingTeleport);
@@ -114,7 +115,6 @@ public class PromptController : MonoBehaviour
     private static ScreenPrompt AddPrompt(string text, PromptPosition position, Key key)
     {
         Enum.TryParse(key.ToString().Replace("Digit", "Alpha"), out KeyCode keyCode);
-
         return AddPrompt(text, position, keyCode);
     }
 
@@ -127,6 +127,27 @@ public class PromptController : MonoBehaviour
         var prompt = new ScreenPrompt(text, sprite);
         Locator.GetPromptManager().AddScreenPrompt(prompt, position, false);
 
+        return prompt;
+    }
+
+    private static ScreenPrompt AddPrompt(string text, PromptPosition position, IInputCommands cmd)
+    {
+        var prompt = new ScreenPrompt(cmd, text);
+        Locator.GetPromptManager().AddScreenPrompt(prompt, position, false);
+        return prompt;
+    }
+
+    private static ScreenPrompt AddPrompt(string text, PromptPosition position)
+    {
+        var prompt = new ScreenPrompt(text);
+        Locator.GetPromptManager().AddScreenPrompt(prompt, position, false);
+        return prompt;
+    }
+
+    private static ScreenPrompt AddPrompt(string text, PromptPosition position, List<IInputCommands> commands, ScreenPrompt.MultiCommandType cmdType)
+    {
+        var prompt = new ScreenPrompt(commands, text, cmdType);
+        Locator.GetPromptManager().AddScreenPrompt(prompt, position, false);
         return prompt;
     }
 }


### PR DESCRIPTION
- Roll the camera with the vanilla flight roll controls, so it works on controller
- Change move speed exponentially instead of linearly, so it doesn't take so long to get between 'moving around at a player scale' speeds and 'moving around at a planetary scale' speeds (and you can get slower than the old minimum, for looking at things up close)
- Use tool up and down as secondary speed controls, again for controller purposes
- Fixed things not being scaled by (unscaled) delta time, inverted axes, etc, so it controls more like the player camera

Also tweaked some things with the parenting while I was at it:
- Teleporting to the player now parents you to the player camera rather than body, and matches the player's rotation
- You get parented to the player by default on start instead of ending up floating away vaguely nearby at the world origin
- You can use Y to switch parent without teleporting, useful for switching between the player and the planet they're on etc