### PR TITLE
Introduced a near clip plane setting

### DIFF
--- a/FreeCam/MainClass.cs
+++ b/FreeCam/MainClass.cs
@@ -20,7 +20,8 @@ class MainClass : ModBehaviour
 
 	private InputMode _storedMode;
 	private int _fov;
-	private ICommonCameraAPI _commonCameraAPI;
+    private int _nearClipPlane;
+    private ICommonCameraAPI _commonCameraAPI;
 	private GameObject _hud;
 	private static MainClass _instance;
 
@@ -62,14 +63,17 @@ class MainClass : ModBehaviour
 	public override void Configure(IModConfig config)
 	{
 		_fov = config.GetSettingsValue<int>("FOV");
-		ShowPrompts = !config.GetSettingsValue<bool>("Hide Prompts");
+        _nearClipPlane = config.GetSettingsValue<int>("Near Clip Plane Distance");
+        ShowPrompts = !config.GetSettingsValue<bool>("Hide Prompts");
 
 		// If the mod is currently active we can set these immediately
 		if (_camera != null)
 		{
 			_camera.fieldOfView = _fov;
 			_owCamera.fieldOfView = _fov;
-		}
+            _camera.nearClipPlane = _nearClipPlane;
+            _owCamera.nearClipPlane = _nearClipPlane;
+        }
 	}
 
 	private void OnSceneLoaded(Scene scene, LoadSceneMode _)

--- a/FreeCam/default-config.json
+++ b/FreeCam/default-config.json
@@ -2,7 +2,7 @@
   "enabled": true,
     "settings": {
         "FOV": 90,
-        "Near Clip Plane Distance": 0.1,
+        "Near Clip Plane Distance": 1,
         "Hide Prompts": false
     }
 }

--- a/FreeCam/default-config.json
+++ b/FreeCam/default-config.json
@@ -1,7 +1,8 @@
 {
   "enabled": true,
-  "settings": {
-    "FOV": 90,
-    "Hide Prompts": false
-  }
+    "settings": {
+        "FOV": 90,
+        "Near Clip Plane Distance": 0.1,
+        "Hide Prompts": false
+    }
 }


### PR DESCRIPTION
Hi!

I needed to be able to control the [near clip plane](https://docs.unity3d.com/ScriptReference/Camera-nearClipPlane.html) in order to capture any interior scenes for my series of ["Outer Wilds Reimagined as Disco Elysium"](https://www.reddit.com/r/outerwilds/comments/1fjprzj/outer_wilds_reimagined_in_the_style_of_disco/). This was because, to create a pseudo-isometric perspective, I had a tiny tiny FOV 2° and the camera really _really_  far away. But this meant that I was restricted to taking screenshots only in wide open areas.

This addition allows the near clip plane to be modified, so that objects near to the camera can be hidden 

Examples of low FOV screenshots not possible without this addition:
![Screenshot (60)](https://github.com/user-attachments/assets/31dcca1a-5522-4222-b361-8362f821ca58)
![Screenshot (65)](https://github.com/user-attachments/assets/38aea90f-cf3e-4602-8d85-9a95cb9e1352)

